### PR TITLE
Support supplying a query to limit pages to be indexed

### DIFF
--- a/plugins/search-confluence-backend/README.md
+++ b/plugins/search-confluence-backend/README.md
@@ -25,6 +25,10 @@ confluence:
   # See https://confluence.atlassian.com/conf59/spaces-792498593.html
   spaces: [ENG]
 
+  # Additional filter of pages to index. In CQL (confluence query language).
+  # See https://developer.atlassian.com/server/confluence/advanced-searching-using-cql/
+  query: 'label = "backstage"'
+
   # Authentication credentials towards Confluence API
   auth:
     username: ${CONFLUENCE_USERNAME}

--- a/plugins/search-confluence-backend/config.d.ts
+++ b/plugins/search-confluence-backend/config.d.ts
@@ -14,6 +14,13 @@ export interface Config {
     spaces: string[];
 
     /**
+     * CQL (Confluence query language) query of pages to index
+     * Will be combined with `spaces` configuration parameter.
+     * @visibility backend
+     */
+    query: string;
+
+    /**
      * @visibility backend
      */
     auth: {


### PR DESCRIPTION
Hello! Hoping you will either accept or give feedback on this change! Thank you for your work on this plugin.

# Context
At my organization, we want the Docs search in Backstage to be a fresh start. So we only want to index old confluence pages that we know are high quality. This plugin already supports filtering by space but this is not specific enough for our needs.

# This change
This change supports an additional CQL query to be configured in app-config.yaml which will further limit the pages returned beyond what the user passes in for the `spaces` config option. This will allow us to tag the pages that we want indexed in backstage.

# edge cases
I'm not sure there is a way of properly escaping input from config parameters to avoid injection of values causing the query to behave in unexpected ways (eg a quote in a space name). I don't think this is a problem since the query is being passed to the REST GET search endpoint so I don't imagine it could do much damage but I'm happy to hear feedback on that.

# Testing
I didn't write any automated tests since I'm a node beginner and I didn't find existing tests to add to.

For manual testing, I tried the following:
- `spaces: ['~marguerite']`, `query` not defined: ensured all pages in space were indexed
- `spaces: ['~marguerite', 'infra']`, `query` not defined: ensured all pages in both spaces were indexed
- `spaces: ['~marguerite']`, `query: 'label = "stompy"'`: ensured only pages in `~marguerite` space with label `stompy` were indexed
- `spaces: ['~marguerite', 'infra']`, `query: 'label = "stompy"'`: ensured only pages in either space with label stompy were indexed

Is there other testing you'd like me to do?