### PR TITLE
feat: added Personal Access Token authentication method

### DIFF
--- a/plugins/search-confluence-backend/README.md
+++ b/plugins/search-confluence-backend/README.md
@@ -33,6 +33,27 @@ confluence:
     password: ${CONFLUENCE_PASSWORD}
 ```
 
+You can also use a Personal Authentication Token with:
+
+```yaml
+# app-config.yaml
+confluence:
+  # Confluence base URL for wiki API
+  # Typically: https://{org-name}.atlassian.net/wiki
+  wikiUrl: https://org-name.atlassian.net/wiki
+
+  # List of spaces to index
+  # See https://confluence.atlassian.com/conf59/spaces-792498593.html
+  spaces: [ENG]
+
+  # Authentication credentials towards Confluence API
+  auth:
+    usePAT: true
+    # While Confluence supports BASIC authentication, using an API token is preferred.
+    # See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+    pat: ${CONFLUENCE_PAT}
+```
+
 Enable Confluence documents indexing in the search engine:
 
 ```typescript

--- a/plugins/search-confluence-backend/src/search/ConfluenceCollatorFactory/ConfluenceCollatorFactory.ts
+++ b/plugins/search-confluence-backend/src/search/ConfluenceCollatorFactory/ConfluenceCollatorFactory.ts
@@ -1,214 +1,241 @@
-import { Config } from '@backstage/config';
-import { DocumentCollatorFactory, IndexableDocument } from '@backstage/plugin-search-common';
+import {Config} from '@backstage/config';
+import {DocumentCollatorFactory, IndexableDocument} from '@backstage/plugin-search-common';
 import fetch from 'node-fetch';
 import pLimit from 'p-limit';
-import { Readable } from 'stream';
-import { Logger } from 'winston';
-import { ConfluenceDocument, ConfluenceDocumentList, IndexableAncestorRef, IndexableConfluenceDocument } from './types';
+import {Readable} from 'stream';
+import {Logger} from 'winston';
+import {ConfluenceDocument, ConfluenceDocumentList, IndexableAncestorRef, IndexableConfluenceDocument} from './types';
 
 type ConfluenceCollatorOptions = {
-    logger: Logger;
+  logger: Logger;
 
-    parallelismLimit: number;
+  parallelismLimit: number;
 
-    wikiUrl: string;
-    spaces: string[];
-    auth: {
-        username: string;
-        password: string;
-    };
+  wikiUrl: string;
+  spaces: string[];
+  auth: {
+    username: string;
+    password: string;
+    pat: string;
+  };
 }
 
 export interface UserEntityDocument extends IndexableDocument {
-    kind: string;
-    login: string;
-    email: string;
+  kind: string;
+  login: string;
+  email: string;
 }
 
 export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
-    public readonly type: string = 'confluence';
+  public readonly type: string = 'confluence';
 
-    private logger: Logger;
+  private logger: Logger;
 
-    private parallelismLimit: number;
-    private wikiUrl: string;
-    private spaces: string[];
-    private auth: {username: string, password: string};
+  private parallelismLimit: number;
+  private wikiUrl: string;
+  private spaces: string[];
+  private auth: { username: string, password: string, pat: string };
 
-    static fromConfig(
-        config: Config,
-        options: {
-            logger: Logger,
-            parallelismLimit?: number,
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: Logger,
+      parallelismLimit?: number,
+    },
+  ) {
+    if (config.has('confluence.auth.usePAT') && config.getBoolean('confluence.auth.usePAT')) {
+      return new ConfluenceCollatorFactory({
+        logger: options.logger,
+
+        parallelismLimit: options.parallelismLimit || 15,
+
+        wikiUrl: config.getString('confluence.wikiUrl'),
+        spaces: config.getStringArray('confluence.spaces'),
+        auth: {
+          pat: config.getString('confluence.auth.pat'),
+          username: '',
+          password: '',
         },
-    ) {
-        return new ConfluenceCollatorFactory({
-            logger: options.logger,
+      });
+    }
+    return new ConfluenceCollatorFactory({
+      logger: options.logger,
 
-            parallelismLimit: options.parallelismLimit || 15,
+      parallelismLimit: options.parallelismLimit || 15,
 
-            wikiUrl: config.getString('confluence.wikiUrl'),
-            spaces: config.getStringArray('confluence.spaces'),
-            auth: {
-                username: config.getString('confluence.auth.username'),
-                password: config.getString('confluence.auth.password'),
-            },
-        });
+      wikiUrl: config.getString('confluence.wikiUrl'),
+      spaces: config.getStringArray('confluence.spaces'),
+      auth: {
+        pat: '',
+        username: config.getString('confluence.auth.username'),
+        password: config.getString('confluence.auth.password'),
+      },
+    });
+  }
+
+  private constructor(options: ConfluenceCollatorOptions) {
+    this.logger = options.logger;
+
+    this.parallelismLimit = options.parallelismLimit;
+    this.wikiUrl = options.wikiUrl;
+    this.spaces = options.spaces;
+    this.auth = options.auth;
+  }
+
+  async getCollator() {
+    return Readable.from(this.execute());
+  }
+
+  private async* execute(): AsyncGenerator<IndexableConfluenceDocument> {
+    const spacesList = await this.getSpaces();
+    const documentsList = await this.getDocumentsFromSpaces(spacesList);
+
+    const limit = pLimit(this.parallelismLimit);
+    const documentsInfo = documentsList.map(document => limit(async () => {
+      try {
+        return this.getDocumentInfo(document);
+      } catch (err) {
+        this.logger.warn(`error while indexing document "${document}"`, err);
+      }
+
+      return [];
+    }));
+
+    const safePromises = documentsInfo.map(promise => promise.catch(error => {
+      this.logger.warn(error);
+
+      return [];
+    }));
+
+    const documents = (await Promise.all(safePromises)).flat();
+
+    for (const document of documents) {
+      yield document;
+    }
+  }
+
+  private async getSpaces(): Promise<string[]> {
+    return this.spaces;
+  }
+
+  /*
+  private async getSpaces(): Promise<string[]> {
+      const data = await this.get(
+          `${this.wikiUrl}/rest/api/space?&limit=1000&type=global&status=current`,
+      );
+
+      if (!data.results) {
+          return [];
+      }
+
+      const spacesList = [];
+      for (const result of data.results) {
+          spacesList.push(result.key);
+      }
+
+      return spacesList;
+  }
+  */
+
+  private async getDocumentsFromSpaces(spaces: string[]): Promise<string[]> {
+    const documentsList = [];
+
+    for (const space of spaces) {
+      documentsList.push(...(await this.getDocumentsFromSpace(space)));
     }
 
-    private constructor(options: ConfluenceCollatorOptions) {
-        this.logger = options.logger;
+    return documentsList;
+  }
 
-        this.parallelismLimit = options.parallelismLimit;
-        this.wikiUrl = options.wikiUrl;
-        this.spaces = options.spaces;
-        this.auth = options.auth;
+  private async getDocumentsFromSpace(space: string): Promise<string[]> {
+    const documentsList = [];
+
+    this.logger.info(`exploring space ${space}`);
+
+    let next = true;
+    let requestUrl = `${this.wikiUrl}/rest/api/content?limit=1000&status=current&spaceKey=${space}`;
+    while (next) {
+      const data = await this.get<ConfluenceDocumentList>(requestUrl);
+      if (!data.results) {
+        break;
+      }
+
+      documentsList.push(...data.results.map(result => result._links.self));
+
+      if (data._links.next) {
+        requestUrl = `${this.wikiUrl}${data._links.next}`;
+      } else {
+        next = false;
+      }
     }
 
-    async getCollator() {
-        return Readable.from(this.execute());
+    return documentsList;
+  }
+
+  private async getDocumentInfo(documentUrl: string): Promise<IndexableConfluenceDocument[]> {
+    this.logger.debug(`fetching document content ${documentUrl}`);
+
+    const data = await this.get<ConfluenceDocument>(`${documentUrl}?expand=body.storage,space,ancestors,version`);
+    if (!data.status || data.status !== 'current') {
+      return [];
     }
 
-    private async *execute(): AsyncGenerator<IndexableConfluenceDocument> {
-        const spacesList = await this.getSpaces();
-        const documentsList = await this.getDocumentsFromSpaces(spacesList);
+    const ancestors: IndexableAncestorRef[] = [
+      {
+        title: data.space.name,
+        location: `${this.wikiUrl}${data.space._links.webui}`,
+      },
+    ];
 
-        const limit = pLimit(this.parallelismLimit);
-        const documentsInfo = documentsList.map(document => limit(async () => {
-            try {
-                return this.getDocumentInfo(document);
-            } catch (err) {
-                this.logger.warn(`error while indexing document "${document}"`, err);
-            }
+    data.ancestors.forEach(ancestor => {
+      ancestors.push({
+        title: ancestor.title,
+        location: `${this.wikiUrl}${ancestor._links.webui}`,
+      });
+    });
 
-            return [];
-        }));
+    return [{
+      title: data.title,
+      text: this.stripHtml(data.body.storage.value),
+      location: `${this.wikiUrl}${data._links.webui}`,
+      spaceKey: data.space.key,
+      spaceName: data.space.name,
+      ancestors: ancestors,
+      lastModifiedBy: data.version.by.publicName,
+      lastModified: data.version.when,
+      lastModifiedFriendly: data.version.friendlyWhen
+    }];
+  }
 
-        const safePromises = documentsInfo.map(promise => promise.catch(error => {
-            this.logger.warn(error);
-
-            return [];
-        }));
-
-        const documents = (await Promise.all(safePromises)).flat();
-
-        for (const document of documents) {
-            yield document;
-        }
+  private async get<T = any>(requestUrl: string): Promise<T> {
+    let res;
+    if (this.auth.pat === '') {
+      const base64Auth = Buffer.from(`${this.auth.username}:${this.auth.password}`, 'utf-8').toString('base64');
+      res = await fetch(requestUrl, {
+        method: 'get',
+        headers: {
+          Authorization: `Basic ${base64Auth}`,
+        },
+      });
+    } else {
+      res = await fetch(requestUrl, {
+        method: 'get',
+        headers: {
+          Authorization: `Bearer ${this.auth.pat}`,
+        },
+      });
     }
 
-    private async getSpaces(): Promise<string[]> {
-        return this.spaces;
+    if (!res.ok) {
+      this.logger.warn('non-ok response from confluence', requestUrl, res.status, await res.text());
+
+      throw new Error(`Request failed with ${res.status} ${res.statusText}`);
     }
 
-    /*
-    private async getSpaces(): Promise<string[]> {
-        const data = await this.get(
-            `${this.wikiUrl}/rest/api/space?&limit=1000&type=global&status=current`,
-        );
+    return await res.json();
+  }
 
-        if (!data.results) {
-            return [];
-        }
-
-        const spacesList = [];
-        for (const result of data.results) {
-            spacesList.push(result.key);
-        }
-
-        return spacesList;
-    }
-    */
-
-    private async getDocumentsFromSpaces(spaces: string[]): Promise<string[]> {
-        const documentsList = [];
-
-        for (const space of spaces) {
-            documentsList.push(...(await this.getDocumentsFromSpace(space)));
-        }
-
-        return documentsList;
-    }
-
-    private async getDocumentsFromSpace(space: string): Promise<string[]> {
-        const documentsList = [];
-
-        this.logger.info(`exploring space ${space}`);
-
-        let next = true;
-        let requestUrl = `${this.wikiUrl}/rest/api/content?limit=1000&status=current&spaceKey=${space}`;
-        while (next) {
-            const data = await this.get<ConfluenceDocumentList>(requestUrl);
-            if (!data.results) {
-                break;
-            }
-
-            documentsList.push(...data.results.map(result => result._links.self));
-
-            if (data._links.next) {
-                requestUrl = `${this.wikiUrl}${data._links.next}`;
-            } else {
-                next = false;
-            }
-        }
-
-        return documentsList;
-    }
-
-    private async getDocumentInfo(documentUrl: string): Promise<IndexableConfluenceDocument[]> {
-        this.logger.debug(`fetching document content ${documentUrl}`);
-
-        const data = await this.get<ConfluenceDocument>(`${documentUrl}?expand=body.storage,space,ancestors,version`);
-        if (!data.status || data.status !== 'current') {
-            return [];
-        }
-
-        const ancestors: IndexableAncestorRef[] = [
-            {
-                title: data.space.name,
-                location: `${this.wikiUrl}${data.space._links.webui}`,
-            },
-        ];
-
-        data.ancestors.forEach(ancestor => {
-            ancestors.push({
-                title: ancestor.title,
-                location: `${this.wikiUrl}${ancestor._links.webui}`,
-            });
-        });
-
-        return [{
-            title: data.title,
-            text: this.stripHtml(data.body.storage.value),
-            location: `${this.wikiUrl}${data._links.webui}`,
-            spaceKey: data.space.key,
-            spaceName: data.space.name,
-            ancestors: ancestors,
-            lastModifiedBy: data.version.by.publicName,
-            lastModified: data.version.when,
-            lastModifiedFriendly: data.version.friendlyWhen
-        }];
-    }
-
-    private async get<T = any>(requestUrl: string): Promise<T> {
-        const base64Auth = Buffer.from(`${this.auth.username}:${this.auth.password}`, 'utf-8').toString('base64');
-        const res = await fetch(requestUrl, {
-            method: 'get',
-            headers: {
-                Authorization: `Basic ${base64Auth}`,
-            },
-        });
-
-        if (!res.ok) {
-            this.logger.warn('non-ok response from confluence', requestUrl, res.status, await res.text());
-
-            throw new Error(`Request failed with ${res.status} ${res.statusText}`);
-        }
-
-        return await res.json();
-    }
-
-    private stripHtml(input: string): string {
-        return input.replace(/(<([^>]+)>)/gi, "");
-    }
+  private stripHtml(input: string): string {
+    return input.replace(/(<([^>]+)>)/gi, "");
+  }
 }


### PR DESCRIPTION
Added 2 fields in config to allow authentication to Confluence via Personal Access Token.
It will look for `usePAT` in config and if it is set to `true`, it will look for `pat` value and use this as the Bearer token in the request to Confluence