### PR TITLE
Feature: Fetch confluence spaces from API

### DIFF
--- a/plugins/search-confluence-backend/README.md
+++ b/plugins/search-confluence-backend/README.md
@@ -23,6 +23,8 @@ confluence:
 
   # List of spaces to index
   # See https://confluence.atlassian.com/conf59/spaces-792498593.html
+  # If missing or if empty, the list of spaces will be populated using
+  # the confluence API via /rest/api/space?&limit=1000&type=global&status=current
   spaces: [ENG]
 
   # Authentication credentials towards Confluence API

--- a/plugins/search-confluence-backend/src/search/ConfluenceCollatorFactory/ConfluenceCollatorFactory.ts
+++ b/plugins/search-confluence-backend/src/search/ConfluenceCollatorFactory/ConfluenceCollatorFactory.ts
@@ -1,214 +1,243 @@
 import { Config } from '@backstage/config';
-import { DocumentCollatorFactory, IndexableDocument } from '@backstage/plugin-search-common';
+import {
+  DocumentCollatorFactory,
+  IndexableDocument,
+} from '@backstage/plugin-search-common';
 import fetch from 'node-fetch';
 import pLimit from 'p-limit';
 import { Readable } from 'stream';
 import { Logger } from 'winston';
-import { ConfluenceDocument, ConfluenceDocumentList, IndexableAncestorRef, IndexableConfluenceDocument } from './types';
+import {
+  ConfluenceDocument,
+  ConfluenceDocumentList,
+  IndexableAncestorRef,
+  IndexableConfluenceDocument,
+} from './types';
 
 type ConfluenceCollatorOptions = {
-    logger: Logger;
+  logger: Logger;
 
-    parallelismLimit: number;
+  parallelismLimit: number;
 
-    wikiUrl: string;
-    spaces: string[];
-    auth: {
-        username: string;
-        password: string;
-    };
-}
+  wikiUrl: string;
+  spaces?: string[];
+  auth: {
+    username: string;
+    password: string;
+  };
+};
 
 export interface UserEntityDocument extends IndexableDocument {
-    kind: string;
-    login: string;
-    email: string;
+  kind: string;
+  login: string;
+  email: string;
 }
 
 export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
-    public readonly type: string = 'confluence';
+  public readonly type: string = 'confluence';
 
-    private logger: Logger;
+  private logger: Logger;
 
-    private parallelismLimit: number;
-    private wikiUrl: string;
-    private spaces: string[];
-    private auth: {username: string, password: string};
+  private parallelismLimit: number;
+  private wikiUrl: string;
+  private spaces: string[];
+  private auth: { username: string; password: string };
 
-    static fromConfig(
-        config: Config,
-        options: {
-            logger: Logger,
-            parallelismLimit?: number,
-        },
-    ) {
-        return new ConfluenceCollatorFactory({
-            logger: options.logger,
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: Logger;
+      parallelismLimit?: number;
+    },
+  ) {
+    return new ConfluenceCollatorFactory({
+      logger: options.logger,
 
-            parallelismLimit: options.parallelismLimit || 15,
+      parallelismLimit: options.parallelismLimit || 15,
 
-            wikiUrl: config.getString('confluence.wikiUrl'),
-            spaces: config.getStringArray('confluence.spaces'),
-            auth: {
-                username: config.getString('confluence.auth.username'),
-                password: config.getString('confluence.auth.password'),
-            },
-        });
-    }
+      wikiUrl: config.getString('confluence.wikiUrl'),
+      spaces: config.getOptionalStringArray('confluence.spaces')
+        ? config.getStringArray('confluence.spaces')
+        : [],
+      auth: {
+        username: config.getString('confluence.auth.username'),
+        password: config.getString('confluence.auth.password'),
+      },
+    });
+  }
 
-    private constructor(options: ConfluenceCollatorOptions) {
-        this.logger = options.logger;
+  private constructor(options: ConfluenceCollatorOptions) {
+    this.logger = options.logger;
 
-        this.parallelismLimit = options.parallelismLimit;
-        this.wikiUrl = options.wikiUrl;
-        this.spaces = options.spaces;
-        this.auth = options.auth;
-    }
+    this.parallelismLimit = options.parallelismLimit;
+    this.wikiUrl = options.wikiUrl;
+    this.spaces = options.spaces || [];
+    this.auth = options.auth;
+  }
 
-    async getCollator() {
-        return Readable.from(this.execute());
-    }
+  async getCollator() {
+    return Readable.from(this.execute());
+  }
 
-    private async *execute(): AsyncGenerator<IndexableConfluenceDocument> {
-        const spacesList = await this.getSpaces();
-        const documentsList = await this.getDocumentsFromSpaces(spacesList);
+  private async *execute(): AsyncGenerator<IndexableConfluenceDocument> {
+    const spacesList = await this.getSpaces();
+    const documentsList = await this.getDocumentsFromSpaces(spacesList);
 
-        const limit = pLimit(this.parallelismLimit);
-        const documentsInfo = documentsList.map(document => limit(async () => {
-            try {
-                return this.getDocumentInfo(document);
-            } catch (err) {
-                this.logger.warn(`error while indexing document "${document}"`, err);
-            }
-
-            return [];
-        }));
-
-        const safePromises = documentsInfo.map(promise => promise.catch(error => {
-            this.logger.warn(error);
-
-            return [];
-        }));
-
-        const documents = (await Promise.all(safePromises)).flat();
-
-        for (const document of documents) {
-            yield document;
-        }
-    }
-
-    private async getSpaces(): Promise<string[]> {
-        return this.spaces;
-    }
-
-    /*
-    private async getSpaces(): Promise<string[]> {
-        const data = await this.get(
-            `${this.wikiUrl}/rest/api/space?&limit=1000&type=global&status=current`,
-        );
-
-        if (!data.results) {
-            return [];
+    const limit = pLimit(this.parallelismLimit);
+    const documentsInfo = documentsList.map(document =>
+      limit(async () => {
+        try {
+          return this.getDocumentInfo(document);
+        } catch (err) {
+          this.logger.warn(`error while indexing document "${document}"`, err);
         }
 
-        const spacesList = [];
-        for (const result of data.results) {
-            spacesList.push(result.key);
-        }
+        return [];
+      }),
+    );
 
-        return spacesList;
+    const safePromises = documentsInfo.map(promise =>
+      promise.catch(error => {
+        this.logger.warn(error);
+
+        return [];
+      }),
+    );
+
+    const documents = (await Promise.all(safePromises)).flat();
+
+    for (const document of documents) {
+      yield document;
     }
-    */
+  }
 
-    private async getDocumentsFromSpaces(spaces: string[]): Promise<string[]> {
-        const documentsList = [];
+  // private async getSpaces(): Promise<string[]> {
+  //     return this.spaces;
+  // }
 
-        for (const space of spaces) {
-            documentsList.push(...(await this.getDocumentsFromSpace(space)));
-        }
+  private async getSpaces(): Promise<string[]> {
+    if (this.spaces?.length === 0) {
+      const data = await this.get(
+        `${this.wikiUrl}/rest/api/space?&limit=1000&type=global&status=current`,
+      );
 
-        return documentsList;
+      if (!data.results) {
+        return [];
+      }
+
+      const spacesList = [];
+      for (const result of data.results) {
+        spacesList.push(result.key);
+      }
+
+      return spacesList;
     }
+    return this.spaces;
+  }
 
-    private async getDocumentsFromSpace(space: string): Promise<string[]> {
-        const documentsList = [];
+  private async getDocumentsFromSpaces(spaces: string[]): Promise<string[]> {
+    const documentsList = [];
 
-        this.logger.info(`exploring space ${space}`);
-
-        let next = true;
-        let requestUrl = `${this.wikiUrl}/rest/api/content?limit=1000&status=current&spaceKey=${space}`;
-        while (next) {
-            const data = await this.get<ConfluenceDocumentList>(requestUrl);
-            if (!data.results) {
-                break;
-            }
-
-            documentsList.push(...data.results.map(result => result._links.self));
-
-            if (data._links.next) {
-                requestUrl = `${this.wikiUrl}${data._links.next}`;
-            } else {
-                next = false;
-            }
-        }
-
-        return documentsList;
-    }
-
-    private async getDocumentInfo(documentUrl: string): Promise<IndexableConfluenceDocument[]> {
-        this.logger.debug(`fetching document content ${documentUrl}`);
-
-        const data = await this.get<ConfluenceDocument>(`${documentUrl}?expand=body.storage,space,ancestors,version`);
-        if (!data.status || data.status !== 'current') {
-            return [];
-        }
-
-        const ancestors: IndexableAncestorRef[] = [
-            {
-                title: data.space.name,
-                location: `${this.wikiUrl}${data.space._links.webui}`,
-            },
-        ];
-
-        data.ancestors.forEach(ancestor => {
-            ancestors.push({
-                title: ancestor.title,
-                location: `${this.wikiUrl}${ancestor._links.webui}`,
-            });
-        });
-
-        return [{
-            title: data.title,
-            text: this.stripHtml(data.body.storage.value),
-            location: `${this.wikiUrl}${data._links.webui}`,
-            spaceKey: data.space.key,
-            spaceName: data.space.name,
-            ancestors: ancestors,
-            lastModifiedBy: data.version.by.publicName,
-            lastModified: data.version.when,
-            lastModifiedFriendly: data.version.friendlyWhen
-        }];
+    for (const space of spaces) {
+      documentsList.push(...(await this.getDocumentsFromSpace(space)));
     }
 
-    private async get<T = any>(requestUrl: string): Promise<T> {
-        const base64Auth = Buffer.from(`${this.auth.username}:${this.auth.password}`, 'utf-8').toString('base64');
-        const res = await fetch(requestUrl, {
-            method: 'get',
-            headers: {
-                Authorization: `Basic ${base64Auth}`,
-            },
-        });
+    return documentsList;
+  }
 
-        if (!res.ok) {
-            this.logger.warn('non-ok response from confluence', requestUrl, res.status, await res.text());
+  private async getDocumentsFromSpace(space: string): Promise<string[]> {
+    const documentsList = [];
 
-            throw new Error(`Request failed with ${res.status} ${res.statusText}`);
-        }
+    this.logger.info(`exploring space ${space}`);
 
-        return await res.json();
+    let next = true;
+    let requestUrl = `${this.wikiUrl}/rest/api/content?limit=1000&status=current&spaceKey=${space}`;
+    while (next) {
+      const data = await this.get<ConfluenceDocumentList>(requestUrl);
+      if (!data.results) {
+        break;
+      }
+
+      documentsList.push(...data.results.map(result => result._links.self));
+
+      if (data._links.next) {
+        requestUrl = `${this.wikiUrl}${data._links.next}`;
+      } else {
+        next = false;
+      }
     }
 
-    private stripHtml(input: string): string {
-        return input.replace(/(<([^>]+)>)/gi, "");
+    return documentsList;
+  }
+
+  private async getDocumentInfo(
+    documentUrl: string,
+  ): Promise<IndexableConfluenceDocument[]> {
+    this.logger.debug(`fetching document content ${documentUrl}`);
+
+    const data = await this.get<ConfluenceDocument>(
+      `${documentUrl}?expand=body.storage,space,ancestors,version`,
+    );
+    if (!data.status || data.status !== 'current') {
+      return [];
     }
+
+    const ancestors: IndexableAncestorRef[] = [
+      {
+        title: data.space.name,
+        location: `${this.wikiUrl}${data.space._links.webui}`,
+      },
+    ];
+
+    data.ancestors.forEach(ancestor => {
+      ancestors.push({
+        title: ancestor.title,
+        location: `${this.wikiUrl}${ancestor._links.webui}`,
+      });
+    });
+
+    return [
+      {
+        title: data.title,
+        text: this.stripHtml(data.body.storage.value),
+        location: `${this.wikiUrl}${data._links.webui}`,
+        spaceKey: data.space.key,
+        spaceName: data.space.name,
+        ancestors: ancestors,
+        lastModifiedBy: data.version.by.publicName,
+        lastModified: data.version.when,
+        lastModifiedFriendly: data.version.friendlyWhen,
+      },
+    ];
+  }
+
+  private async get<T = any>(requestUrl: string): Promise<T> {
+    const base64Auth = Buffer.from(
+      `${this.auth.username}:${this.auth.password}`,
+      'utf-8',
+    ).toString('base64');
+    const res = await fetch(requestUrl, {
+      method: 'get',
+      headers: {
+        Authorization: `Basic ${base64Auth}`,
+      },
+    });
+
+    if (!res.ok) {
+      this.logger.warn(
+        'non-ok response from confluence',
+        requestUrl,
+        res.status,
+        await res.text(),
+      );
+
+      throw new Error(`Request failed with ${res.status} ${res.statusText}`);
+    }
+
+    return await res.json();
+  }
+
+  private stripHtml(input: string): string {
+    return input.replace(/(<([^>]+)>)/gi, '');
+  }
 }


### PR DESCRIPTION
This change revisits the commented out function `getSpaces()` currently on main, making the default method for importing spaces an API call to confluence, and retaining the spaces key as option for backward compatibility.

The new behaviour will be as follow:

If the YAML key `spaces` is present and it's length is > 0 then the collator will fetch the listed spaces.
If the key is missing, the list of spaces will be generated via an API call to the `/rest/api/space?&limit=1000&type=global&status=current` endpoint. 