### PR TITLE
Add Custom Icon Capability 

### DIFF
--- a/plugins/search-confluence/src/components/ConfluenceResultListItem/ConfluenceResultListItem.tsx
+++ b/plugins/search-confluence/src/components/ConfluenceResultListItem/ConfluenceResultListItem.tsx
@@ -8,14 +8,15 @@ import { HighlightedSearchResultText } from '@backstage/plugin-search-react';
 import {
   Box,
   Breadcrumbs,
-  Divider,
-  ListItem,
   ListItemIcon,
   ListItemText,
   makeStyles,
 } from '@material-ui/core';
 
 const useStyles = makeStyles({
+  flexContainer: {
+    flexWrap: 'wrap',
+  },
   lastUpdated: {
     display: 'block',
     marginTop: '0.2rem',
@@ -29,6 +30,8 @@ const useStyles = makeStyles({
     marginTop: '1rem',
   },
   itemText: {
+    width: '100%',
+    marginBottom: '1rem',
     wordBreak: 'break-all',
   },
 });
@@ -125,17 +128,15 @@ export const ConfluenceResultListItem = ({
 
   return (
     <>
-      <ListItem alignItems="center">
-        <ListItemIcon title="Confluence document">{resultIcon}</ListItemIcon>
+      <ListItemIcon title="Confluence document">{resultIcon}</ListItemIcon>
+      <div className={classes.flexContainer}>
         <ListItemText
           primary={title}
           secondary={excerpt}
           className={classes.itemText}
           primaryTypographyProps={{ variant: 'h6' }}
         />
-      </ListItem>
-
-      <Divider component="li" />
+      </div>
     </>
   );
 };

--- a/plugins/search-confluence/src/components/ConfluenceResultListItem/ConfluenceResultListItem.tsx
+++ b/plugins/search-confluence/src/components/ConfluenceResultListItem/ConfluenceResultListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Link } from '@backstage/core-components';
 import {
   IndexableDocument,
@@ -45,12 +45,14 @@ export type IndexableConfluenceDocument = IndexableDocument & {
 };
 
 export interface ConfluenceResultItemProps {
+  icon?: ReactNode | ((result: any) => ReactNode);
   result?: IndexableDocument;
   highlight?: ResultHighlight;
   rank?: number;
 }
 
 export const ConfluenceResultListItem = ({
+  icon,
   result,
   highlight,
 }: ConfluenceResultItemProps) => {
@@ -109,17 +111,22 @@ export const ConfluenceResultListItem = ({
     </>
   );
 
+  let resultIcon: ConfluenceResultItemProps['icon'] = (
+    <img
+      width="20"
+      height="20"
+      src="https://cdn.worldvectorlogo.com/logos/confluence-1.svg"
+      alt="confluence logo"
+    />
+  );
+  if (icon) {
+    resultIcon = typeof icon === 'function' ? icon(result) : icon;
+  }
+
   return (
     <>
       <ListItem alignItems="center">
-        <ListItemIcon title="Confluence document">
-          <img
-            width="20"
-            height="20"
-            src="https://cdn.worldvectorlogo.com/logos/confluence-1.svg"
-            alt="confluence logo"
-          />
-        </ListItemIcon>
+        <ListItemIcon title="Confluence document">{resultIcon}</ListItemIcon>
         <ListItemText
           primary={title}
           secondary={excerpt}


### PR DESCRIPTION
Other result list items, e.g. [TechDocs](https://github.com/backstage/backstage/blob/master/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx#L40) have the ability to pass custom icons. This patch adds the same functionality to this plugin. My TypeScript isn't great, so please let me know if there's anything you want me to change :)

This patch lets us have icons that match in theme by specifying a custom icon:

<img width="918" alt="Screenshot 2023-06-05 at 5 04 47 PM" src="https://github.com/K-Phoen/backstage-plugin-confluence/assets/107639398/f67b184c-af40-463d-9535-2252e9ef8067">

This change also aligns the styles used with upstream Backstage, so the icons line up:

<img width="875" alt="Screenshot 2023-06-05 at 5 11 21 PM" src="https://github.com/K-Phoen/backstage-plugin-confluence/assets/107639398/02b671ce-bd2e-4dba-b52c-b5c01dc5ef38">
